### PR TITLE
use shopify-app bridge client-side redirect to shopify auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ SHOPIFY_API_PUBLIC_KEY='your public api key from the Shopify app dashboard here'
 SHOPIFY_API_PRIVATE_KEY='your private api key from the Shopify app dashboard here'
 NEXT_PUBLIC_SHOPIFY_API_PUBLIC_KEY='same value as SHOPIFY_API_PUBLIC_KEY, this will expose your public key to the frontend'
 SHOPIFY_AUTH_CALLBACK_URL='<your-sub-domain>.ngrok.io/api/auth/callback'
+NEXT_PUBLIC_SHOPIFY_AUTH_CALLBACK_URL='same value as SHOPIFY_AUTH_CALLBACK_URL, this will expose your callback url to the frontend'
 SHOPIFY_AUTH_SCOPES='read_customers,write_customers' # a comma separated list of Shopify Auth scopes your app requires to function
+NEXT_PUBLIC_SHOPIFY_AUTH_SCOPES='same value as SHOPIFY_AUTH_SCOPES, this will expose your auth scopes to the frontend'
 HOME_PATH = '/home' # or wherever you'd like the user to be sent to after successfully authenticating
 ```
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,30 +1,26 @@
 import React, { useEffect } from "react";
-import qs from "querystring";
-import axios from 'axios';
-
+import createApp from '@shopify/app-bridge';
+import { Redirect } from '@shopify/app-bridge/actions';
 
 export default function Home() {
   // page context params
   useEffect(() => {
-    if (typeof window !== "undefined" && window.location) {
-      const query = qs.parse(window.location.search);
-      axios
-        .post("/api/auth", {
-          query: query,
-        })
-        .then((response) => {
-          if (response.data.redirectTo) {
-            if (window.parent) {
-              window.parent.location.href = response.data.redirectTo;
-            } else {
-              window.location.href = response.data.redirectTo;
-            }
-          }
-        })
-        .catch(function (error) {
-          // handle error
-          console.error(error);
-        });
+    const apiKey = process.env.NEXT_PUBLIC_SHOPIFY_API_PUBLIC_KEY;
+    const redirectUri = process.env.NEXT_PUBLIC_SHOPIFY_AUTH_CALLBACK_URL;
+    const shopOrigin = new URLSearchParams(window.location.search).get("shop");
+    const scopes = process.env.NEXT_PUBLIC_SHOPIFY_AUTH_SCOPES;
+    const permissionUrl = `https://${shopOrigin}/admin/oauth/authorize?client_id=${apiKey}&scope=${scopes}&redirect_uri=${redirectUri}`;
+
+    // If the current window is the 'parent', change the URL by setting location.href
+    if (window.top == window.self) {
+      window.location.assign(permissionUrl);
+    // If the current window is the 'child', change the parent's URL with Shopify App Bridge's Redirect action
+    } else {
+      const app = createApp({
+        apiKey: apiKey,
+        shopOrigin: shopOrigin
+      });
+      Redirect.create(app).dispatch(Redirect.Action.REMOTE, permissionUrl);
     }
   }, []);
 


### PR DESCRIPTION
Fixes issue with redirection failing on cold boot on vercel: https://github.com/ctrlaltdylan/shopify-session-tokens-nextjs/issues/4

This pull request uses the Shopify App Bridge to do a client side redirect directly to Shopify instead of the previous ajax post followed by a redirect to Shopify Auth.